### PR TITLE
from import xray to import xarray as xray in analogs.py

### DIFF
--- a/paleopy/core/analogs.py
+++ b/paleopy/core/analogs.py
@@ -2,7 +2,7 @@ import os
 import numpy as np
 from numpy import ma
 import json
-import xray
+import xarray as xray
 import bottleneck  as bn
 from matplotlib.mlab import detrend_linear
 from scipy.stats import ttest_ind


### PR DESCRIPTION
modified analogs.py (in paleopy/core) so that it calls xarray as xray instead of xray (an older, deprecated version of xarray)